### PR TITLE
Add register plugin script

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -6,13 +6,9 @@ import 'ckeditor4';
 
 // this should be ran on every page
 import activateThebelab from './activateThebelab';
+import loadPlugin from './plugin';
 
-// plugin registration
-import './plugin';
-
-CKEDITOR.config.extraPlugins = 'enableBinder';
-// plugin registraion end
-
+loadPlugin();
 CKEDITOR.replace('editor');
 
 const thebelabConfig = {

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -14,14 +14,20 @@ const insertPreWithBinder = (editor) => {
   editor.insertElement(element);
 };
 
-CKEDITOR.plugins.add('enableBinder', {
-  init: (editor) => {
-    editor.addCommand('insertPreWithBinder', { exec: insertPreWithBinder });
-    editor.ui.addButton('enableBinder', {
-      label: 'Enable Binder',
-      command: 'insertPreWithBinder',
-      toolbar: 'editing',
-      icon: 'https://binderhub.readthedocs.io/en/latest/_static/favicon.png',
-    });
-  },
-});
+const loadPlugin = () => {
+  CKEDITOR.plugins.add('enableBinder', {
+    init: (editor) => {
+      editor.addCommand('insertPreWithBinder', { exec: insertPreWithBinder });
+      editor.ui.addButton('enableBinder', {
+        label: 'Enable Binder',
+        command: 'insertPreWithBinder',
+        toolbar: 'editing',
+        icon: 'https://binderhub.readthedocs.io/en/latest/_static/favicon.png',
+      });
+    },
+  });
+
+  CKEDITOR.config.extraPlugins = 'enableBinder';
+};
+
+export default loadPlugin;

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -1,0 +1,29 @@
+import loadPlugin from './plugin.js'
+
+// Select the node that will be observed for mutations
+const targetNode = document.getElementsByTagName('head')[0];
+
+// Options for the observer (which mutations to observe)
+const config = { attributes: false, childList: true, subtree: false };
+
+// Callback function to execute when mutations are observed
+const callback = function(mutationsList, observer) {
+  // Use traditional 'for loops' for IE 11
+  for(let mutation of mutationsList) {
+    if (mutation.addedNodes.length === 0) continue;
+    const node = mutation.addedNodes[0];
+
+    // listen for the editor.js script to be added
+    if (node.tagName === 'SCRIPT' && node.src.includes('editor.js')) {
+      // load plugin when the editor script is loaded
+      node.addEventListener('load', loadPlugin);
+      observer.disconnect();
+    }
+  }
+};
+
+// Create an observer instance linked to the callback function
+const observer = new MutationObserver(callback);
+
+// Start observing the target node for configured mutations
+observer.observe(targetNode, config);

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -11,12 +11,6 @@ module.exports = {
     path: Path.join(__dirname, '../build'),
     filename: 'js/[name].js'
   },
-  optimization: {
-    splitChunks: {
-      chunks: 'all',
-      name: false
-    }
-  },
   plugins: [
     new CleanWebpackPlugin(),
     new CopyWebpackPlugin([

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -9,7 +9,6 @@ module.exports = merge(common, {
   stats: 'errors-only',
   bail: true,
   entry: {
-    app: Path.resolve(__dirname, '../src/scripts/index.js'),
     plugin: Path.resolve(__dirname, '../src/scripts/plugin.js'),
   },
   output: {

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -9,7 +9,7 @@ module.exports = merge(common, {
   stats: 'errors-only',
   bail: true,
   entry: {
-    plugin: Path.resolve(__dirname, '../src/scripts/plugin.js'),
+    registerPlugin: Path.resolve(__dirname, '../src/scripts/registerPlugin.js'),
   },
   output: {
     filename: 'js/[name].[chunkhash:8].js',

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -1,6 +1,6 @@
+const Path = require('path');
 const Webpack = require('webpack');
 const merge = require('webpack-merge');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
@@ -8,6 +8,10 @@ module.exports = merge(common, {
   devtool: 'source-map',
   stats: 'errors-only',
   bail: true,
+  entry: {
+    app: Path.resolve(__dirname, '../src/scripts/index.js'),
+    plugin: Path.resolve(__dirname, '../src/scripts/plugin.js'),
+  },
   output: {
     filename: 'js/[name].[chunkhash:8].js',
     chunkFilename: 'js/[name].[chunkhash:8].chunk.js'
@@ -17,9 +21,6 @@ module.exports = merge(common, {
       'process.env.NODE_ENV': JSON.stringify('production')
     }),
     new Webpack.optimize.ModuleConcatenationPlugin(),
-    new MiniCssExtractPlugin({
-      filename: 'bundle.css'
-    })
   ],
   module: {
     rules: [
@@ -31,9 +32,9 @@ module.exports = merge(common, {
       {
         test: /\.s?css/i,
         use : [
-          MiniCssExtractPlugin.loader,
+          'style-loader',
           'css-loader',
-          'sass-loader'
+          'sass-loader',
         ]
       }
     ]


### PR DESCRIPTION
Create a register plugin script that we can copy and paste to Libretexts footer.

* The script listens to `editor.js` and register the plugin right after the script is loaded
* Update webpack settings to bundle the register script in production build