### PR TITLE
Add `plugin.scss` to overwrite MindTouch css settings

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -1,3 +1,4 @@
+import '../styles/plugin.scss';
 import activateThebelab from './activateThebelab';
 
 const thebelabConfig = {

--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -1,0 +1,6 @@
+// force overwirte css settings from MindTouch
+.cke_button_icon.cke_button__enablebinder_icon {
+  background-image: url(https://binderhub.readthedocs.io/en/latest/_static/favicon.png?t=JB9B) !important;
+  background-position: 0 0px !important;
+  background-size: 16px !important;
+}


### PR DESCRIPTION
This PR fixes the issue that the plugin icon is not shown in production.

In order not to deal with MindTouch in general. I use a `style loader` to auto inject css instead of separate css to another file.