### PR TITLE
use setHtml instead of setText

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -133,7 +133,7 @@ const dialogConfig = (editor) => ({
 
         const outputBlock = editor.document.createElement('div');
         outputBlock.setAttribute('data-output', 'true');
-        outputBlock.setText(output);
+        outputBlock.setHtml(output);
         editor.insertElement(outputBlock);
       }
     }


### PR DESCRIPTION
resolves #6.

`setText` filters tags which will prevent img tags to show. Use `setHtml` instead.