### PR TITLE
Fix/dialog scroll

### DIFF
--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -14,6 +14,11 @@
   .cke_dialog {
     position: static !important;
 
+    // this fixes the close button
+    td[role=presentation] {
+      position: relative;
+    }
+
     .cke_dialog_contents_body {
       display: block;
       width: 100% !important;

--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -4,3 +4,19 @@
   background-position: 0 0px !important;
   background-size: 16px !important;
 }
+
+// fix dialog scroll
+.cke_editor_editarea_dialog {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .cke_dialog {
+    position: static !important;
+
+    .cke_dialog_contents_body {
+      display: block;
+      width: 100% !important;
+    }
+  }
+}


### PR DESCRIPTION
Resolves #5. Change the dialog content body to `display: block` instead of using `display: table`. Displaying as table messes up height settings and will prevent the scrollbar to show.

> Note that this is based on #12, so this must be merged after #12 is merged.