### PR TITLE
Move toolbar button initialization into plugin.js

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -159,7 +159,11 @@ const loadPlugin = () => {
     },
   });
 
-  CKEDITOR.config.extraPlugins = 'enableBinder';
+  if (CKEDITOR.config.extraPlugins === '') {
+    CKEDITOR.config.extraPlugins += 'enableBinder';
+  } else {
+    CKEDITOR.config.extraPlugins += ',enableBinder';
+  }
 };
 
 export default loadPlugin;

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -2,7 +2,10 @@ import loadPlugin from './plugin';
 import activateThebelab from './activateThebelab';
 
 // Adds this plugin to the LibreEditor for later activation
-LibreEditor.binderPlugin = loadPlugin;
+LibreEditor.binderPlugin = (config) => {
+  loadPlugin();
+  config.toolbar[12].push('enableBinder');
+};
 
 // activate thebelab on every page if data-executable exists
 $(document).ready(() => { activateThebelab(); });


### PR DESCRIPTION
This migrates the creation of the toolbar button to within the plugin.

If desired, we can move the CKEDITOR.config.extraPlugins initialization to the LibreEditor code.

Important TODO: Remove the duplicate code from the editor configuration once this is merged into master.