### PR TITLE
Changing the language of all code blocks if the language in one code block changes

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -25,8 +25,13 @@ const dataLanguageDictionary = {
 const getLanguage = (editor) => {
   const blockList = editor.document.getElementsByTag('pre');
   let language = 'Python 3';
-  if (blockList.count() !== 0) {
-    language = dataLanguageDictionary[blockList.getItem(0).getAttribute('data-language')];
+  let i = 0;
+  for (i = 0; i < blockList.count(); i += 1) {
+    const codeBlock = (blockList.toArray())[i];
+    if (codeBlock.getAttribute('data-language')) {
+      language = dataLanguageDictionary[codeBlock.getAttribute('data-language')];
+      break;
+    }
   }
   return language;
 };
@@ -72,7 +77,9 @@ const changeAllLanguages = (editor, language = 'python3') => {
   // changes the data-language attribute of all pre tags
   const blockList = editor.document.getElementsByTag('pre');
   blockList.toArray().forEach((codeBlock) => {
-    codeBlock.setAttribute('data-language', language);
+    if (codeBlock.getAttribute('data-language')) {
+      codeBlock.setAttribute('data-language', language);
+    }
   });
 };
 

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -14,6 +14,23 @@ const languageDictionary = {
   SageMath: ['SageMath'],
 };
 
+const dataLanguageDictionary = {
+  python3: ['Python 3'],
+  julia: ['Julia'],
+  R: ['R'],
+  octave: ['Octave'],
+  SageMath: ['SageMath'],
+};
+
+const getLanguage = (editor) => {
+  const blockList = editor.document.getElementsByTag('pre');
+  let language = 'Python 3';
+  if(blockList.count() != 0) {
+    language = dataLanguageDictionary[blockList.getItem(0).getAttribute('data-language')];
+  }
+  return language;
+}
+
 const editScriptAreaHTML = (language = 'python3') => {
   const sample = {
     python3: {
@@ -51,6 +68,15 @@ const editScriptAreaHTML = (language = 'python3') => {
   `;
 };
 
+const changeAllLanguages = (editor, language = 'python3') => {
+  // changes the data-language attribute of all pre tags
+  const blockList = editor.document.getElementsByTag('pre');
+  let i = 0;
+  for(i = 0; i < blockList.count(); i++) {
+    blockList.getItem(i).setAttribute('data-language', language);
+  }
+}
+
 const insertWarning = () => `
     <label class="warning"> Please do not click OK until code has finished executing. </label>`;
 
@@ -60,6 +86,9 @@ const dialogConfig = (editor) => ({
   minHeight: 100,
   minWidth: 400,
   onShow() {
+    const dialog = this;
+    const language = getLanguage(editor);
+    dialog.setValueOf('tab-basic', 'language', language);
     activateThebelab(thebelabConfig);
     this.resize(500, 500);
   },
@@ -119,6 +148,15 @@ const dialogConfig = (editor) => ({
     const language = languageDictionary[dialog.getValueOf('tab-basic', 'language')];
     const noOutput = dialog.getValueOf('tab-basic', 'no-output');
     const noCode = dialog.getValueOf('tab-basic', 'no-code');
+
+    // changes the data-language attributes of all pre tags in editor
+    changeAllLanguages(editor, language);
+
+    // creates code block to be inserted into text editor
+    const codeBlock = editor.document.createElement('pre');
+    codeBlock.setAttribute('class', 'code_input');
+    codeBlock.setAttribute('data-executable', 'true');
+    codeBlock.setAttribute('data-language', language);
     const cm = document.querySelector('.cke_dialog_contents .thebelab-input .CodeMirror').CodeMirror;
     const code = cm.getValue();
 

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -25,11 +25,11 @@ const dataLanguageDictionary = {
 const getLanguage = (editor) => {
   const blockList = editor.document.getElementsByTag('pre');
   let language = 'Python 3';
-  if(blockList.count() != 0) {
+  if (blockList.count() !== 0) {
     language = dataLanguageDictionary[blockList.getItem(0).getAttribute('data-language')];
   }
   return language;
-}
+};
 
 const editScriptAreaHTML = (language = 'python3') => {
   const sample = {
@@ -71,11 +71,10 @@ const editScriptAreaHTML = (language = 'python3') => {
 const changeAllLanguages = (editor, language = 'python3') => {
   // changes the data-language attribute of all pre tags
   const blockList = editor.document.getElementsByTag('pre');
-  let i = 0;
-  for(i = 0; i < blockList.count(); i++) {
-    blockList.getItem(i).setAttribute('data-language', language);
-  }
-}
+  blockList.toArray().forEach((codeBlock) => {
+    codeBlock.setAttribute('data-language', language);
+  });
+};
 
 const insertWarning = () => `
     <label class="warning"> Please do not click OK until code has finished executing. </label>`;
@@ -89,8 +88,15 @@ const dialogConfig = (editor) => ({
     const dialog = this;
     const language = getLanguage(editor);
     dialog.setValueOf('tab-basic', 'language', language);
-    activateThebelab(thebelabConfig);
     this.resize(500, 500);
+  },
+  onCancel() {
+    const dialog = this;
+    const editorLanguage = getLanguage(editor);
+    const dialogLanguage = dialog.getValueOf('tab-basic', 'language');
+    if (editorLanguage !== dialogLanguage) {
+      activateThebelab(thebelabConfig);
+    }
   },
   contents: [
     {
@@ -152,11 +158,6 @@ const dialogConfig = (editor) => ({
     // changes the data-language attributes of all pre tags in editor
     changeAllLanguages(editor, language);
 
-    // creates code block to be inserted into text editor
-    const codeBlock = editor.document.createElement('pre');
-    codeBlock.setAttribute('class', 'code_input');
-    codeBlock.setAttribute('data-executable', 'true');
-    codeBlock.setAttribute('data-language', language);
     const cm = document.querySelector('.cke_dialog_contents .thebelab-input .CodeMirror').CodeMirror;
     const code = cm.getValue();
 


### PR DESCRIPTION
Attempts to close #3.

When the language in the dialog is changed and the user clicks `OK`, the language of the code blocks in the editor also change.
When the dialog opens, the language of the first code block is pre-set as the language of the editor. I imagine that users who keep writing many code blocks would get tired of changing the language every time they open the dialog.
If the user changed the language of the kernel, but clicked `cancel`, the kernel that Thebelab is currently connected to reverts back to the kernel language of the editor.