### PR TITLE
Resize dialog to 500 x 500

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -57,6 +57,7 @@ const dialogConfig = (editor) => ({
   minWidth: 400,
   onShow() {
     activateThebelab(thebelabConfig);
+    this.resize(500, 500);
   },
   contents: [
     {


### PR DESCRIPTION
Closes #26 
Calls the resize command instead of changing the minHeight and minWidth since I thought the user should have the option to make the dialog window smaller than the default dimensions.