### PR TITLE
load require.js & direct to python-env repo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
     <title>CKeditor Binder Plugin</title>
   </head>
   <body>

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -34,7 +34,8 @@ const getLanguage = () => {
 const getConfig = (language) => {
   const config = {
     binderOptions: {
-      repo: 'binder-examples/requirements',
+      repo: 'LibreTexts/ckeditor-binder-plugin',
+      ref: 'Python-Env'
       binderUrl,
     },
     kernelOptions: {

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -35,7 +35,7 @@ const getConfig = (language) => {
   const config = {
     binderOptions: {
       repo: 'LibreTexts/ckeditor-binder-plugin',
-      ref: 'Python-Env'
+      ref: 'Python-Env',
       binderUrl,
     },
     kernelOptions: {


### PR DESCRIPTION
index.html loads require.js, and activateThebelab.js points to our private python repo