### PR TITLE
force scrollbar to show but only under columbia-skin in mindtouch

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,15 @@
+.columbia-skin-elm {
+  .cke_dialog {
+    .cke_dialog_contents {
+      tbody {
+        tr {
+          td {
+            display: block;
+            overflow: auto;
+            width: 100% !important;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolve #5 and resolve #32.

This is a Mindtouch specific fix. I intend to write the CSS so that only the Mindtouch editor will be affected.