### PR TITLE
Set ref for all language

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -46,18 +46,22 @@ const getConfig = (language) => {
   switch (language) {
     case 'SageMath':
       config.binderOptions.repo = 'sagemath/sage-binder-env';
+      config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'sagemath';
       break;
     case 'julia':
       config.binderOptions.repo = 'binder-examples/demo-julia';
+      config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'julia-1.1';
       break;
     case 'octave':
       config.binderOptions.repo = 'binder-examples/octave';
+      config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'octave';
       break;
     case 'R':
       config.binderOptions.repo = 'binder-examples/r';
+      config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'ir';
       break;
     case 'python3':


### PR DESCRIPTION
### The Bug
The dialog is unable to load repo when language is not set to Python. In #34 we set default `config.binderOptions.ref` to `Python-env`. However the repo for other languages are still using the master branch. This causes a url error because there is no `Python-env` branch on those repos.