### PR TITLE
Add deploy script to test.libretexts.org

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,11 @@
+HOME_DIR=/home/jupyterteam
+
+ssh -tt jupyterteam@test.libretexts.org << EOF
+cd $HOME_DIR/ckeditor-binder-plugin
+git fetch --all && git reset --hard origin/master
+yarn install
+yarn build
+cp build/js/registerPlugin.min.js* $HOME_DIR/public
+exit
+EOF
+


### PR DESCRIPTION
Now our script will be host on test.libretexts.org and we need some way to deploy it. This PR includes a script that will ssh and do a deploy.