### PR TITLE
Use global var to get widget from dialog

### DIFF
--- a/src/scripts/dialog.js
+++ b/src/scripts/dialog.js
@@ -107,7 +107,9 @@ const dialogConfig = (editor) => ({
     dialog.setValueOf('tab-basic', 'language', language);
 
     // set code and output
-    const widget = dialog.getModel(editor);
+    // getModel is not supported on older versions
+    // const widget = dialog.getModel(editor);
+    const widget = window.currentEditedThebelabWidgetByBinderDialog;
     const preTag = widget.element.findOne('pre[data-executable]');
     let code = '';
     if (preTag) {
@@ -197,7 +199,11 @@ const dialogConfig = (editor) => ({
   // We only need to set the correct widget data.
   onOk() {
     const dialog = this;
-    const widget = dialog.getModel(editor);
+
+    // getModel is not supported on older versions
+    // const widget = dialog.getModel(editor);
+    const widget = window.currentEditedThebelabWidgetByBinderDialog;
+
     const language = languageDictionary[dialog.getValueOf('tab-basic', 'language')];
 
     // changes the data-language attributes of all pre tags in editor

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -65,6 +65,15 @@ const widgetConfig = {
     if (outputDiv) {
       this.setData('output', outputDiv.getHtml());
     }
+
+    // every time each widget is edited, it should pass it to
+    // the dialog so that the dialog can access it. this is done
+    // in here https://github.com/ckeditor/ckeditor4/blob/master/plugins/widget/plugin.js#L1217
+    // However, it is not not supported on older versions
+    // here is a hack that attaches it as a global var
+    this.on('edit', () => {
+      window.currentEditedThebelabWidgetByBinderDialog = this;
+    });
   },
   template,
 


### PR DESCRIPTION
### What Happened?

`dialog.getModel` doesn't work on production. This is only supported on newer versions. It is set [here](https://github.com/ckeditor/ckeditor4/blob/master/plugins/widget/plugin.js#L1217) on the `edit` events of the widgets.

### How it is solved

Set `window.currentWidget` on `edit` events of the widgets so that the dialog can access it. I understand this is a bad fix to use global variables. However, under time limits, this is the only fix I can think of right now.

@celine168 It is currently test deployed. You can see how it works on production.