### PR TITLE
Load Require.js dynamically

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "thebelab": "readable",
     "LibreEditor": "readable",
     "$": "readable",
+    "define": "readable",
   },
   "rules": {
     "new-cap": [

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -1,14 +1,4 @@
-const loadThebelabScript = () => new Promise((resolve, reject) => {
-  if (window.thebelab !== undefined) resolve();
-
-  const script = document.createElement('script');
-
-  script.onload = () => { resolve(); };
-  script.onerror = () => { reject(); };
-
-  script.src = 'https://unpkg.com/thebelab@0.5.1/lib/index.js';
-  document.head.appendChild(script);
-});
+import loadScript from './ultility';
 
 const binderUrl = 'https://mybinder.org';
 
@@ -81,13 +71,17 @@ const activateThebelab = (config, detectLanguage = true) => {
       mergeConfig = Object.assign(mergeConfig, getConfig(getLanguage()));
     }
 
-    loadThebelabScript()
-      .then(() => {
-        thebelab.bootstrap(mergeConfig);
-      })
-      .catch(() => {
-        // todo: deal with error handling
-      });
+    if (window.thebelab === undefined) {
+      loadScript('https://unpkg.com/thebelab@0.5.1/lib/index.js')
+        .then(() => {
+          thebelab.bootstrap(mergeConfig);
+        })
+        .catch(() => {
+          // todo: deal with error handling
+        });
+    } else {
+      thebelab.bootstrap(mergeConfig);
+    }
   }
 };
 

--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -104,7 +104,6 @@ const dialogConfig = (editor) => ({
   onShow() {
     const dialog = this;
     const language = getLanguage(editor);
-    dialog.setValueOf('tab-basic', 'language', language);
 
     // set code and output
     // getModel is not supported on older versions
@@ -132,6 +131,8 @@ const dialogConfig = (editor) => ({
     codeArea.setHtml(editScriptAreaHTML(languageDictionary[language], code, output));
 
     this.resize(500, 500);
+
+    dialog.setValueOf('tab-basic', 'language', language);
   },
   onCancel() {
     const dialog = this;

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -8,12 +8,22 @@ LibreEditor.binderPlugin = (config) => {
   config.toolbar[12].push('enableBinder');
 };
 
-while (true) {
-  if ($ !== undefined && $.fn.dataTable !== undefined) {
-    loadScript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');
-    break;
-  }
-}
+// overwrite getter and setter of $.fn.dataTable because we need to load requirejs after it is set
+Object.defineProperty($.fn, 'dataTable', {
+  get() {
+    return this.privateDataTable;
+  },
+  set(value) {
+    // need this to avoid infinite loops
+    // if we just use `this.dataTable`, it will trigger the setter again
+    this.privateDataTable = value;
+
+    // check if requirejs is already there
+    if (typeof define !== 'function' || !define.amd) {
+      loadScript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');
+    }
+  },
+});
 
 // activate thebelab on every page if data-executable exists
 $(document).ready(() => { activateThebelab(); });

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -1,11 +1,19 @@
 import loadPlugin from './plugin';
 import activateThebelab from './activateThebelab';
+import loadScript from './ultility';
 
 // Adds this plugin to the LibreEditor for later activation
 LibreEditor.binderPlugin = (config) => {
   loadPlugin();
   config.toolbar[12].push('enableBinder');
 };
+
+while (true) {
+  if ($ !== undefined && $.fn.dataTable !== undefined) {
+    loadScript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');
+    break;
+  }
+}
 
 // activate thebelab on every page if data-executable exists
 $(document).ready(() => { activateThebelab(); });

--- a/src/scripts/ultility.js
+++ b/src/scripts/ultility.js
@@ -1,0 +1,11 @@
+const loadScript = (url) => new Promise((resolve, reject) => {
+  const script = document.createElement('script');
+
+  script.onload = () => { resolve(); };
+  script.onerror = () => { reject(); };
+
+  script.src = url;
+  document.head.appendChild(script);
+});
+
+export default loadScript;


### PR DESCRIPTION
### What happened?
Error message `e.$grid.dataTable is not a function` appear when including `requirejs`.

### Why does it happen?

This is caused because jQuery plugin dataTable is not available under the global variable `window.$`. This is because the dataTable plugin supports [AMD](https://requirejs.org/docs/whyamd.html) modules such that if requirejs exists, it will register the entire plugin as a module instead of under the global jQuery. Thus, other code will not be able to access dataTable through the global jQuery.

### How does this PR fix this?

This PR addresses this problem by simply load requirejs after the dataTable plugin is loaded. However, it is not easy to detect this since dataTable plugin is loaded dynamically by `pro.js` on MindTouch. Since the plugin registers itself by assigning the object to `$.fn.dataTable`, my approach is to register a setter on `$.fn.dataTable` in the first place. The setter will trigger a `loadScript` function that loads requirejs after it is set. This ensures that dataTable is correctly registered.

> See [here](https://github.com/DataTables/DataTables/blob/master/media/js/jquery.dataTables.js#L30) on how dataTable is loaded.

### Potential concerns

Although this approach fixes dataTable, requirejs does prevent any additional plugin that supports AMD modules to be available globally. So if any other plugin is needed in the future, we will need some other mechanism to ensure all plugin is loaded properly, and then load requirejs.