### PR TITLE
Added feedback text

### DIFF
--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -93,6 +93,14 @@ const getCodeMirror = () => {
   return cm ? cm.CodeMirror : null;
 };
 
+const insertFeedback = () => `
+  <label class="warning">
+    Have feedback? <a href="mailto:jupyterteam@ucdavis.edu">Email us</a>
+    or <a href="https://github.com/LibreTexts/ckeditor-binder-plugin/issues" target="_blank">open an issue</a>
+    on our issue tracker.
+  </label>
+`;
+
 const dialogConfig = (editor) => ({
   title: 'Insert Interactive Script',
   minHeight: 100,
@@ -209,6 +217,11 @@ const dialogConfig = (editor) => ({
           type: 'html',
           id: 'insert-warning',
           html: insertWarning(),
+        },
+        {
+          type: 'html',
+          id: 'insert-feedback',
+          html: insertFeedback(),
         },
       ],
     },


### PR DESCRIPTION
Resolves #64 
Links our email group and the issue tracker. 

Example of what it looks like on the dev environment (trailing colons are linked to #65):
![image](https://user-images.githubusercontent.com/22624020/77483346-30affe00-6de5-11ea-94f9-34bbe653c341.png)

I'm hoping that the CSS for links will show up in the actual editor but I don't know if I can test it before sending it to production.