### PR TITLE
Revert "use binder.libretexts.org"

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -10,7 +10,7 @@ const loadThebelabScript = () => new Promise((resolve, reject) => {
   document.head.appendChild(script);
 });
 
-const binderUrl = 'https://binder.libretexts.org';
+const binderUrl = 'https://mybinder.org';
 
 const defaultConfig = {
   binderOptions: {


### PR DESCRIPTION
This reverts commit 2091214d3db2f582ff7d729d95ec5321474c392f.

Since we cannot fix our binder. I suggest reverting to using mybinder.org for deploying to production. We can change it back after we fix it.