### PR TITLE
Redefine html structure

### DIFF
--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -35,6 +35,8 @@ const getLanguage = (editor) => {
   return language;
 };
 
+const wrapPreTag = (code) => `<pre>${code}</pre>`;
+
 const editScriptAreaHTML = (language = 'python', code = null, output = null) => {
   const sample = {
     python: {
@@ -67,7 +69,7 @@ const editScriptAreaHTML = (language = 'python', code = null, output = null) => 
       ${code === null ? sample[language].code : code}
     </pre>
     <div data-output="true">
-      ${output === null ? sample[language].output : output}
+      ${output === null ? wrapPreTag(sample[language].output) : output}
     </div>
   `;
 };
@@ -247,12 +249,12 @@ const dialogConfig = (editor) => ({
     const cm = getCodeMirror();
 
     let output = document.querySelector('.cke_dialog_contents .jp-OutputArea-output');
-    // the output will contain a pre tag if run by binder
+
     // output might be null if no output
-    if (output && output.children.length !== 0 && output.children[0].tagName === 'PRE') {
-      output = output.children[0].innerHTML;
-    } else {
+    if (output) {
       output = output.innerHTML;
+    } else {
+      output = '<pre></pre>';
     }
 
     // pass to widgets to figure out

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -17,7 +17,7 @@ const loadPlugin = () => {
     init: (editor) => {
       // not sure why allowedContent in the widgetConfig
       // won't work. So set it here
-      editor.filter.allow('div(thebelab);pre[data-executable,data-language](no-code);div[data-output]');
+      editor.filter.allow('div(thebelab-widget);pre[data-executable,data-language](no-code);div[data-output]');
 
       CKEDITOR.dialog.add('binderDialog', dialogConfig);
       editor.widgets.add('thebelabWidget', widgetConfig);

--- a/src/scripts/widgetConfig.js
+++ b/src/scripts/widgetConfig.js
@@ -31,12 +31,14 @@ const widgetHtml = (data) => {
 // in front, CKEditor will not like it.
 // use trim() here to remove the spaces.
 const template = `
-  <div class="thebelab">
+  <div class="thebelab-widget">
     <pre data-executable="true" data-language="python3">
       print('hello world')
     </pre>
     <div data-output="true">
-      hello world
+      <pre>
+        hello world
+      </pre>
     </div>
   </div>
 `.trim();
@@ -89,7 +91,7 @@ const widgetConfig = {
     return element;
   },
   upcast(element) {
-    return element.hasClass('thebelab');
+    return element.hasClass('thebelab-widget');
   },
 };
 


### PR DESCRIPTION
Resolves #60.

### Change

* Ensure all output area is wrapped by a `pre` tag.
* Rename top level class to `thebelab-widget` to prevent name collision in the future.