### PR TITLE
Update Julia version

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -42,7 +42,7 @@ const getConfig = (language) => {
     case 'julia':
       config.binderOptions.repo = 'binder-examples/demo-julia';
       config.binderOptions.ref = 'master';
-      config.kernelOptions.kernelName = 'julia-1.1';
+      config.kernelOptions.kernelName = 'julia-1.4';
       break;
     case 'octave':
       config.binderOptions.repo = 'binder-examples/octave';


### PR DESCRIPTION
If we want to prevent this in the future, I think we might want to fork that Julia binder repo and point our Julia kernel to our version so we can keep it stable. I'm not sure why we have to specify the Julia version, but it doesn't seem to work without specifying it.

Fixes #75 