### PR TITLE
Limit thebelab-cell width in dialog

### DIFF
--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -15,6 +15,14 @@
             overflow: auto;
             width: 100% !important;
             max-height: 60vh;
+
+            .thebelab-cell {
+              max-width: 55vw;
+
+              .jp-OutputArea-output {
+                overflow-x: scroll;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
resolved #91.

This is currently test deployed on query site. It solves the problem by limiting the output area of thebelab.