### PR TITLE
Use rich-default as the binder environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM libretexts/default-env:1.14


### PR DESCRIPTION
It looks like our plugin [uses the Python-Env branch](https://github.com/LibreTexts/ckeditor-binder-plugin/blob/0f5418e53a91fb02178664ca637c0a6abc872023/src/scripts/activateThebelab.js#L28) to create an environment for Binder. To quickly resolve https://github.com/LibreTexts/metalc/issues/175, I added a dummy Dockerfile that just uses our `default-env`. This will temporarily solve the issue while we work on a proper repo2docker-compatible rich-default environment. If a Dockerfile is present, it [overrides all other config files](https://mybinder.readthedocs.io/en/latest/config_files.html#dockerfile-advanced-environments), so this should work. Let me know what you think since I haven't touched this plugin or know too much about binderhub.