### PR TITLE
for octave, use the same repo/ref as Python-Env

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -50,8 +50,8 @@ const getConfig = (language) => {
       config.kernelOptions.kernelName = 'julia-1.4';
       break;
     case 'octave':
-      config.binderOptions.repo = 'binder-examples/octave';
-      config.binderOptions.ref = 'master';
+      //config.binderOptions.repo = 'binder-examples/octave';
+      //config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'octave';
       break;
     case 'r':


### PR DESCRIPTION
Combined with #100, this would make the Python and Octave interactive scripts use our rich-default 1.14 image, which should provide more up-to-date packages and plenty of preinstalled packages for users.