### PR TITLE
Add octave packages to octave binder environment

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -50,7 +50,7 @@ const getConfig = (language) => {
       config.kernelOptions.kernelName = 'julia-1.4';
       break;
     case 'octave':
-      config.binderOptions.repo = 'binder-examples/octave';
+      config.binderOptions.repo = 'LibreTexts/jupyter-octave';
       config.binderOptions.ref = 'master';
       config.kernelOptions.kernelName = 'octave';
       break;


### PR DESCRIPTION
Temporarily resolves https://github.com/LibreTexts/metalc/issues/175 by installing all octave packages available via apt. For a more permanent solution, see #100, but this works for most users for now. Tested, the packages are visible inside the plugin.