### PR TITLE
1.2.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor-binder-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A CKeditor plugin that makes adding binder enabled pre tags easy.",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --config webpack/webpack.config.prod.js  --colors",

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -86,7 +86,7 @@ const activateThebelab = (config, detectLanguage = true) => {
   }
 
   // edge warning
-  if (navigator.userAgent.includes("Edge")) {
+  if (navigator.userAgent.includes('Edge')) {
     alert("WARNING: You're using an older version of Edge. All code cells on this page will be broken on your browser. Please update to Chromium Edge or use a different browser.");
   }
 };

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -84,6 +84,11 @@ const activateThebelab = (config, detectLanguage = true) => {
         // todo: deal with error handling
       });
   }
+
+  // edge warning
+  if (navigator.userAgent.includes("Edge")) {
+    alert("WARNING: You're using an older version of Edge. All code cells on this page will be broken on your browser. Please update to Chromium Edge or use a different browser.");
+  }
 };
 
 export default activateThebelab;

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -87,7 +87,8 @@ const activateThebelab = (config, detectLanguage = true) => {
 
   // edge warning
   if (navigator.userAgent.includes('Edge')) {
-    alert("WARNING: You're using an older version of Edge. All code cells on this page will be broken on your browser. Please update to Chromium Edge or use a different browser.");
+    // disable eslint warning, this is meant to be obtrusive
+    alert("WARNING: You're using an older version of Edge. All code cells on this page will be broken on your browser. Please update to Chromium Edge or use a different browser."); // eslint-disable-line no-alert
   }
 };
 


### PR DESCRIPTION
Adds a gigantic warning for old Edge users urging them to update to Chromium Edge (their user agent string has `Edg` instead of `Edge`) otherwise Thebe cells will break.

This closes #108