### PR TITLE
Add aggressive caching binder-plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Sending to DigitalOcean
       uses: LibreTexts/do-space-sync-action@master
       with:
-        args: --acl public-read
+        args: --acl public-read --cache-control "public,max-age=604800"
       env:
         SOURCE_DIR: './build'
         DEST_DIR: 'github/ckeditor-binder-plugin'


### PR DESCRIPTION
Files on production will now  be cached for up to a week in browser caches. (Can be overridden using CTRL+F5).

Addresses ballooning bandwidth overage costs. Related to LibreTexts/ckeditor-query-plugin#3