### PR TITLE
Deploy query with any branch you want to test

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,9 +1,15 @@
 HOME_DIR=/home/jupyterteam
+BRANCH=staging
+
+if [ $# -eq 1 ]
+then
+  BRANCH=$1
+fi
 
 ssh -tt jupyterteam@test.libretexts.org << EOF
 cd $HOME_DIR/ckeditor-binder-plugin
 git fetch --all
-git checkout staging && git reset --hard origin/staging
+git checkout $BRANCH && git reset --hard origin/$BRANCH
 yarn install
 yarn build
 cp build/js/registerPlugin.min.js* $HOME_DIR/public


### PR DESCRIPTION
Now that you can add an argument specify which branch you want to deploy to the test site for easy development. For example:

```bash
bin/deploy.sh feature/deploy-any-branch
```

> Passing no argument will deploy the `staging` branch