### PR TITLE
use SPDX license expression suggested by yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "./node_modules/eslint/bin/eslint.js src"
   },
   "author": "Libretexts Jupyter Team",
-  "license": "GPL-3.0 License",
+  "license": "GPL-3.0-only",
   "devDependencies": {
     "@babel/core": "^7.7.5",
     "@babel/plugin-proposal-class-properties": "^7.7.4",


### PR DESCRIPTION
Yarn is complaining not using SPDX expression for license. See [doument](https://spdx.org/licenses/) for valid values.