### PR TITLE
Add status field

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -62,12 +62,26 @@ const activateThebelab = (config, detectLanguage = true) => {
 
   // check if any pre block with data-executable=true
   if (document.querySelector('[data-executable=true]') !== null) {
+    const language = getLanguage();
     if (detectLanguage) {
-      mergeConfig = Object.assign(mergeConfig, getConfig(getLanguage()));
+      mergeConfig = Object.assign(mergeConfig, getConfig(language));
     }
 
     loadScript('https://unpkg.com/thebelab@0.5.1/lib/index.js')
       .then(() => {
+        thebelab.on('status', (e, data) => {
+          const statusElement = document.getElementsByClassName('thebe-status-field')[0];
+          if (statusElement !== undefined) {
+            statusElement.innerHTML = `${language.toUpperCase()} Session: ${data.status.toUpperCase()}`;
+            statusElement.setAttribute('class', `thebe-status-field thebe-status-${data.status}`);
+
+            if (data.status === 'ready') {
+              setTimeout(() => {
+                statusElement.remove();
+              }, 3000);
+            }
+          }
+        });
         thebelab.bootstrap(mergeConfig);
       })
       .catch(() => {

--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -129,6 +129,34 @@ const insertFeedback = () => `
   </label>
 `;
 
+const insertStatusHtml = (editor, language) => {
+  // remember the current selection so that we can go back
+  // somehow `insertHtml` move cursor to that position
+  const selection = editor.getSelection();
+  const currentRange = selection.getRanges();
+
+  // create range on the top of the document
+  const range = editor.createRange();
+  range.selectNodeContents(editor.document.getBody());
+  range.moveToPosition(editor.document.getBody(), CKEDITOR.POSITION_AFTER_START);
+  range.collapse(); // this sets start and end position to the same
+
+  // insert the HTML
+  editor.insertHtml(`
+    <div class="thebe-status-field">${language.toUpperCase()} Session: NOT STARTED</div>
+  `, 'html', range);
+
+  // go back to original selection
+  selection.selectRanges(currentRange);
+};
+
+const removeStatusHtmlIfAny = (editor) => {
+  const statusField = editor.document.findOne('.thebe-status-field');
+  if (statusField !== null) {
+    statusField.remove();
+  }
+};
+
 const dialogConfig = (editor) => ({
   title: 'Insert Interactive Script',
   minHeight: 100,
@@ -287,6 +315,9 @@ const dialogConfig = (editor) => ({
     widget.setData('noCode', noCode);
     widget.setData('output', output);
     widget.setData('noOutput', noOutput);
+
+    removeStatusHtmlIfAny(editor);
+    insertStatusHtml(editor, language);
   },
 });
 

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -18,6 +18,7 @@ const loadPlugin = () => {
       // not sure why allowedContent in the widgetConfig
       // won't work. So set it here
       editor.filter.allow('div(thebelab-widget);pre[data-executable,data-language](no-code);div[data-output]');
+      editor.filter.allow('div(thebe-status-field)');
 
       CKEDITOR.dialog.add('binderDialog', dialogConfig);
       editor.widgets.add('thebelabWidget', widgetConfig);

--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -51,3 +51,49 @@
   content: '';
 }
 
+$status-field-blue: darken(rgb(229, 245, 254), 20);
+$status-field-green: darken(lightgreen, 20);
+
+.thebe-status-field {
+  position: fixed;
+  bottom: 15px;
+  left: 40px;
+  border: 2px solid rgb(170, 170, 170);
+  padding: 4px;
+  border-radius: 4px;
+  background-color: rgb(249, 249, 249);
+  opacity: 1;
+  display: block;
+  z-index: 10000;
+
+  &.thebe-status-building {
+    /* Binder is building the image */
+    background-color: $status-field-blue;
+  }
+
+  &.thebe-status-built {
+    /* Binder is built the image */
+    background-color: $status-field-blue;
+  }
+
+  &.thebe-status-launching {
+    /* Binder launching the server */
+    background-color: $status-field-blue;
+  }
+
+  &.thebe-status-starting {
+    /* Binder starting the server */
+    background-color: $status-field-blue;
+  }
+
+  &.thebe-status-ready {
+    /* The kernel is connected and ready */
+    background-color: $status-field-green;
+  }
+
+  &.thebe-status-failed {
+    /* Building the image or launching the kernel failed */
+    background-color: red;
+  }
+}
+


### PR DESCRIPTION
Add an HTML element to show the status of our binder connection. Behaves as the follow:

* If there is any code cell added, the code will add one and only one element to indicate status
* the HTML element is located at the bottom left corner
* 3 seconds after status is success, the element will disappear

This branch is currently deployed to https://query.libretexts.org/Development/Stub_2_(Using_R) as a working example.