### PR TITLE
Fix/add status field when loading thebe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor-binder-plugin",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "A CKeditor plugin that makes adding binder enabled pre tags easy.",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --config webpack/webpack.config.prod.js  --colors",

--- a/release/1.5.2.md
+++ b/release/1.5.2.md
@@ -1,0 +1,8 @@
+# 1.5.2
+12/23/2020
+
+Fix status indicator. It will now show on any page with a thebe code cell.
+
+## Changes
+- Fix status field
+

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -56,6 +56,37 @@ const getConfig = (language) => {
   return config;
 };
 
+const insertThebeStatusHTML = (language) => {
+  const body = document.getElementsByTagName('body')[0];
+  const statusField = document.createElement('div');
+  statusField.innerHTML = `${language.toUpperCase()} Session: NOT STARTED`;
+  statusField.setAttribute('class', 'thebe-status-field');
+  body.append(statusField);
+};
+
+const registerThebeStatusEvent = (language) => {
+  thebelab.on('status', (e, data) => {
+    const statusElement = document.getElementsByClassName('thebe-status-field')[0];
+    if (statusElement !== undefined) {
+      statusElement.innerHTML = `${language.toUpperCase()} Session: ${data.status.toUpperCase()}`;
+      statusElement.setAttribute('class', `thebe-status-field thebe-status-${data.status}`);
+
+      if (data.status === 'ready') {
+        setTimeout(() => {
+          statusElement.remove();
+        }, 3000);
+      }
+    }
+  });
+};
+
+const removeStatusHtmlIfAny = () => {
+  const statusField = document.querySelector('.thebe-status-field');
+  if (statusField !== null) {
+    statusField.remove();
+  }
+};
+
 const activateThebelab = (config, detectLanguage = true) => {
   let mergeConfig = config;
   if (!mergeConfig) mergeConfig = defaultConfig;
@@ -69,20 +100,12 @@ const activateThebelab = (config, detectLanguage = true) => {
 
     loadScript('https://unpkg.com/thebelab@0.5.1/lib/index.js')
       .then(() => {
-        thebelab.on('status', (e, data) => {
-          const statusElement = document.getElementsByClassName('thebe-status-field')[0];
-          if (statusElement !== undefined) {
-            statusElement.innerHTML = `${language.toUpperCase()} Session: ${data.status.toUpperCase()}`;
-            statusElement.setAttribute('class', `thebe-status-field thebe-status-${data.status}`);
-
-            if (data.status === 'ready') {
-              setTimeout(() => {
-                statusElement.remove();
-              }, 3000);
-            }
-          }
-        });
         thebelab.bootstrap(mergeConfig);
+        if (detectLanguage) {
+          removeStatusHtmlIfAny();
+          insertThebeStatusHTML(language);
+          registerThebeStatusEvent(language);
+        }
       })
       .catch(() => {
         // todo: deal with error handling

--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -129,34 +129,6 @@ const insertFeedback = () => `
   </label>
 `;
 
-const insertStatusHtml = (editor, language) => {
-  // remember the current selection so that we can go back
-  // somehow `insertHtml` move cursor to that position
-  const selection = editor.getSelection();
-  const currentRange = selection.getRanges();
-
-  // create range on the top of the document
-  const range = editor.createRange();
-  range.selectNodeContents(editor.document.getBody());
-  range.moveToPosition(editor.document.getBody(), CKEDITOR.POSITION_AFTER_START);
-  range.collapse(); // this sets start and end position to the same
-
-  // insert the HTML
-  editor.insertHtml(`
-    <div class="thebe-status-field">${language.toUpperCase()} Session: NOT STARTED</div>
-  `, 'html', range);
-
-  // go back to original selection
-  selection.selectRanges(currentRange);
-};
-
-const removeStatusHtmlIfAny = (editor) => {
-  const statusField = editor.document.findOne('.thebe-status-field');
-  if (statusField !== null) {
-    statusField.remove();
-  }
-};
-
 const dialogConfig = (editor) => ({
   title: 'Insert Interactive Script',
   minHeight: 100,
@@ -315,9 +287,6 @@ const dialogConfig = (editor) => ({
     widget.setData('noCode', noCode);
     widget.setData('output', output);
     widget.setData('noOutput', noOutput);
-
-    removeStatusHtmlIfAny(editor);
-    insertStatusHtml(editor, language);
   },
 });
 

--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -18,7 +18,6 @@ const loadPlugin = () => {
       // not sure why allowedContent in the widgetConfig
       // won't work. So set it here
       editor.filter.allow('div(thebelab-widget);pre[data-executable,data-language](no-code);div[data-output]');
-      editor.filter.allow('div(thebe-status-field)');
 
       CKEDITOR.dialog.add('binderDialog', dialogConfig);
       editor.widgets.add('thebelabWidget', widgetConfig);


### PR DESCRIPTION
Somehow also resolves #128.

Change how we insert Thebe status fields. Now anytime we try to load thebe script, we'll try to insert the status field on that page. This way, any existing page will also have the status field.