### PR TITLE
Hide status field when printing

### DIFF
--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -97,3 +97,8 @@ $status-field-green: darken(lightgreen, 20);
   }
 }
 
+@media print {
+ .thebe-status-field {
+   display: none;
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12994749/103071541-a3b6f280-4578-11eb-89d9-28001ca64ed1.png)
During printing, the status field is obscuring other parts of the content. Added a simple CSS rule to hide the `.thebe-status-field` when printing.
