### PR TITLE
Revert "Add aggressive caching binder-plugin"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Sending to DigitalOcean
       uses: LibreTexts/do-space-sync-action@master
       with:
-        args: --acl public-read --cache-control "public,max-age=604800"
+        args: --acl public-read
       env:
         SOURCE_DIR: './build'
         DEST_DIR: 'github/ckeditor-binder-plugin'


### PR DESCRIPTION
Reverts LibreTexts/ckeditor-binder-plugin#119

Now that I've moved the cache to Cloudflare as of December 1, 2020, this configuration seems to be causing DigitalOcean to be double caching.


If this fix works, then we will also have to revert https://github.com/LibreTexts/ckeditor-query-plugin/pull/3.