### PR TITLE
Bugfix binderUrl

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -5,7 +5,7 @@ const binderUrl = 'https://binder.libretexts.org/';
 const defaultConfig = {
   binderOptions: {
     repo: 'binder-examples/requirements',
-    binderUrl,
+    binderUrl: binderUrl,
   },
 };
 
@@ -26,7 +26,7 @@ const getConfig = (language) => {
     binderOptions: {
       repo: 'LibreTexts/default-env',
       ref: '2.3.1',
-      binderUrl,
+      binderUrl: binderUrl,
     },
     kernelOptions: {
       kernelName: 'python',


### PR DESCRIPTION
binderUrl was not correctly specified as a key-value pair

Also, is the defaultConfig redundant since you are already specifying the default in getConfig?