### PR TITLE
Add ability to override repo using an HTML script

### DIFF
--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -32,13 +32,13 @@ const getConfig = (language) => {
       kernelName: 'python',
     },
   };
-  
-  //check if override #binderRepoConfig exists
-  const binderRepoConfig = document.getElementById('binderRepoConfig');
+ 
+  // check if override #binderRepoConfig exists
+  let binderRepoConfig = document.getElementById('binderRepoConfig');
   if (binderRepoConfig && binderRepoConfig.innerText) {
     binderRepoConfig = binderRepoConfig.innerText;
-    binderRepoConfig = binderRepoConfig.replace("/*<![CDATA[*/","");
-    binderRepoConfig = binderRepoConfig.replace("/*]]>*/","");
+    binderRepoConfig = binderRepoConfig.replace('/*<![CDATA[*/', '');
+    binderRepoConfig = binderRepoConfig.replace('/*]]>*/', '');
     config.binderOptions.repo = binderRepoConfig;
   }
   

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -40,7 +40,7 @@ const getConfig = (language) => {
     binderRepoConfig = binderRepoConfig.replace('/*<![CDATA[*/', '');
     binderRepoConfig = binderRepoConfig.replace('/*]]>*/', '');
     binderRepoConfig = JSON.parse(binderRepoConfig);
-    config.binderOptions = Object.assign(binderOptions, {ref: 'master'}, binderRepoConfig);
+    config.binderOptions = Object.assign(config.binderOptions, { ref: 'master' }, binderRepoConfig);
   }
 
   switch (language) {

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -32,7 +32,7 @@ const getConfig = (language) => {
       kernelName: 'python',
     },
   };
- 
+
   // check if override #binderRepoConfig exists
   let binderRepoConfig = document.getElementById('binderRepoConfig');
   if (binderRepoConfig && binderRepoConfig.innerText) {
@@ -41,7 +41,7 @@ const getConfig = (language) => {
     binderRepoConfig = binderRepoConfig.replace('/*]]>*/', '');
     config.binderOptions.repo = binderRepoConfig;
   }
-  
+
   switch (language) {
     case 'text/x-c++src':
       config.kernelOptions.kernelName = 'xcpp14';

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -32,7 +32,16 @@ const getConfig = (language) => {
       kernelName: 'python',
     },
   };
-
+  
+  //check if override #binderRepoConfig exists
+  const binderRepoConfig = document.getElementById('binderRepoConfig');
+  if (binderRepoConfig && binderRepoConfig.innerText) {
+    binderRepoConfig = binderRepoConfig.innerText;
+    binderRepoConfig = binderRepoConfig.replace("/*<![CDATA[*/","");
+    binderRepoConfig = binderRepoConfig.replace("/*]]>*/","");
+    config.binderOptions.repo = binderRepoConfig;
+  }
+  
   switch (language) {
     case 'text/x-c++src':
       config.kernelOptions.kernelName = 'xcpp14';

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -39,7 +39,8 @@ const getConfig = (language) => {
     binderRepoConfig = binderRepoConfig.innerText;
     binderRepoConfig = binderRepoConfig.replace('/*<![CDATA[*/', '');
     binderRepoConfig = binderRepoConfig.replace('/*]]>*/', '');
-    config.binderOptions.repo = binderRepoConfig;
+    binderRepoConfig = JSON.parse(binderRepoConfig);
+    config.binderOptions = Object.assign(binderOptions, {ref: 'master'}, binderRepoConfig);
   }
 
   switch (language) {


### PR DESCRIPTION
Allows for pages to have a different repo instead of just default-env. This is useful for binder-plugin pages that need repositories with nonstandard plugins or that need to access data files in the repo.

Edit 1/10/21: **BLOCKED by LibreTexts/metalc/issues/213**