### PR TITLE
1.6.1 hotfix

### DIFF
--- a/release/1.6.1.md
+++ b/release/1.6.1.md
@@ -1,0 +1,7 @@
+# 1.6.0
+1/14/21
+
+Hotfix to print the console message in activateThebelab.js rather than index.js
+
+## Changes
+- Version info console.log message is now printing through activateThebelab.js rather than index.js

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -2,6 +2,10 @@ import loadScript from './loadScript';
 
 const binderUrl = 'https://binder.libretexts.org/';
 
+// print CKEditor Binder Plugin version info
+const versionInfo = 'CKEditor Binder Plugin Development Version';
+console.log(versionInfo);
+
 const defaultConfig = {
   binderOptions: {
     repo: 'binder-examples/requirements',

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -8,10 +8,6 @@ import 'ckeditor4';
 import activateThebelab from './activateThebelab';
 import loadPlugin from './plugin';
 
-// print CKEditor Binder Plugin version info
-const versionInfo = 'CKEditor Binder Plugin Development Version';
-console.log(versionInfo);
-
 loadPlugin();
 CKEDITOR.replace('editor');
 


### PR DESCRIPTION
The console message is now printed through `activateThebelab.js` rather than `index.js`. I made a lot of debugging mistakes but basically I'm pretty sure the issue was simply printing `console.log` through `index.js`. This is a very small change so I'm mostly making this PR for documentation purposes. 