### PR TITLE
Release 1.6.2

### DIFF
--- a/release/1.6.2.md
+++ b/release/1.6.2.md
@@ -1,0 +1,8 @@
+# 1.6.2
+1/14/21
+
+Github action to insert version information into the console message now properly points to activateThebelab.js. All instances of 'kernelName' in activateThebelab.js have been changed to 'name' in order to be consistent with the new jupyterhub API used in Thebe 0.6.0.
+
+## Changes
+- .github/workflows/main.yaml now inserts into activateThebelab.js rather than index.js
+- all references to the 'kernelName' configuration option for Thebe in activateThebelab.js have now been changed to 'name'

--- a/src/scripts/activateThebelab.js
+++ b/src/scripts/activateThebelab.js
@@ -33,25 +33,25 @@ const getConfig = (language) => {
       binderUrl,
     },
     kernelOptions: {
-      kernelName: 'python',
+      name: 'python',
     },
   };
 
   switch (language) {
     case 'text/x-c++src':
-      config.kernelOptions.kernelName = 'xcpp14';
+      config.kernelOptions.name = 'xcpp14';
       break;
     case 'sagemath':
-      config.kernelOptions.kernelName = 'sagemath';
+      config.kernelOptions.name = 'sagemath';
       break;
     case 'julia':
-      config.kernelOptions.kernelName = 'julia-1.5';
+      config.kernelOptions.name = 'julia-1.5';
       break;
     case 'octave':
-      config.kernelOptions.kernelName = 'octave';
+      config.kernelOptions.name = 'octave';
       break;
     case 'r':
-      config.kernelOptions.kernelName = 'ir';
+      config.kernelOptions.name = 'ir';
       break;
     case 'python':
     default:


### PR DESCRIPTION
Updates `activateThebelab.js` to use `name` as a configuration option for Thebe rather than `kernelName` so that it is consistent with the new JupyterHub API used in Thebe 0.6.0. This release file also accounts for the changes to `main.yaml` that I made earlier and are currently on master.