### PR TITLE
Fix HTML escaping to prevent xml corruption

### DIFF
--- a/src/scripts/dialogConfig.js
+++ b/src/scripts/dialogConfig.js
@@ -12,12 +12,12 @@ function htmlToCode(str) {
 
 function codeToHtml(str) {
   return String(str)
-    .replace('&', '&amp;')
-    .replace('<', '&lt;')
-    .replace('>', '&gt;')
-    .replace('"', '&quot;')
-    .replace('\'', '&#039;')
-    .replace('`', '&#x60;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&#039;')
+    .replaceAll('`', '&#x60;');
 }
 
 const thebelabConfig = {

--- a/src/scripts/widgetConfig.js
+++ b/src/scripts/widgetConfig.js
@@ -1,9 +1,9 @@
 const codeHtml = (code, language, noCode = false) => {
   if (noCode) {
-    return `<pre data-language="${language}" class="no-code">${code}</pre>`;
+    return `<pre data-language="${language}" class="no-code"><![CDATA[${code}]]></pre>`;
   }
 
-  return `<pre data-executable="true" data-language="${language}">${code}</pre>`;
+  return `<pre data-executable="true" data-language="${language}"><![CDATA[${code}]]></pre>`;
 };
 
 const widgetHtml = (data) => {

--- a/src/scripts/widgetConfig.js
+++ b/src/scripts/widgetConfig.js
@@ -1,9 +1,9 @@
 const codeHtml = (code, language, noCode = false) => {
   if (noCode) {
-    return `<pre data-language="${language}" class="no-code"><![CDATA[${code}]]></pre>`;
+    return `<pre data-language="${language}" class="no-code">${code}</pre>`;
   }
 
-  return `<pre data-executable="true" data-language="${language}"><![CDATA[${code}]]></pre>`;
+  return `<pre data-executable="true" data-language="${language}">${code}</pre>`;
 };
 
 const widgetHtml = (data) => {


### PR DESCRIPTION
Due to how XHTML is handled, any xml that resides in the jupyter codeblock will be interpreted unless CDATA is used. While uncommon, this will cause data corruption for any code containing anything XML-like.

EDIT: It was an escaping-related bug, see bottom comments.

Example, this:
```
MODEL_STRING = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n <!-- Created by COPASI version 4.5.31 (Debug) on 2010-05-11 13:40 with libSBML version 4.1.0-b3. -->\n <sbml xmlns=\"http://www.sbml.org/sbml/level2/version4\" level=\"2\" version=\"4\">\n <model metaid=\"COPASI1\" id=\"Model_1\" name=\"New Model\">\n <listOfUnitDefinitions>\n <unitDefinition id=\"volume\" name=\"volume\">\n <listOfUnits>\n <unit kind=\"litre\" scale=\"-3\"/>\n </listOfUnits>\n </unitDefinition>\n <unitDefinition id=\"substance\" name=\"substance\">\n <listOfUnits>\n <unit kind=\"mole\" scale=\"-3\"/>\n </listOfUnits>\n </unitDefinition>\n <unitDefinition id=\"unit_0\">\n <listOfUnits>\n <unit kind=\"second\" exponent=\"-1\"/>\n </listOfUnits>\n </unitDefinition>\n </listOfUnitDefinitions>\n <listOfCompartments>\n <compartment id=\"compartment_1\" name=\"compartment\" size=\"1\"/>\n </listOfCompartments>\n <listOfSpecies>\n <species metaid=\"COPASI2\" id=\"species_1\" name=\"A\" compartment=\"compartment_1\" initialConcentration=\"1\"/>\n <species metaid=\"COPASI3\" id=\"species_2\" name=\"B\" compartment=\"compartment_1\" initialConcentration=\"0\"/>\n <species metaid=\"COPASI4\" id=\"species_3\" name=\"C\" compartment=\"compartment_1\" initialConcentration=\"0\"/>\n </listOfSpecies>\n <listOfReactions>\n <reaction metaid=\"COPASI5\" id=\"reaction_1\" name=\"reaction_1\" reversible=\"false\">\n <listOfReactants>\n <speciesReference species=\"species_1\"/>\n </listOfReactants>\n <listOfProducts>\n <speciesReference species=\"species_2\"/>\n </listOfProducts>\n <kineticLaw>\n <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n <apply>\n <times/>\n <ci> compartment_1 </ci>\n <ci> k1 </ci>\n <ci> species_1 </ci>\n </apply>\n </math>\n <listOfParameters>\n <parameter id=\"k1\" name=\"k1\" value=\"0.2\" units=\"unit_0\"/>\n </listOfParameters>\n </kineticLaw>\n </reaction>\n <reaction metaid=\"COPASI6\" id=\"reaction_2\" name=\"reaction_2\" reversible=\"false\">\n <listOfReactants>\n <speciesReference species=\"species_2\"/>\n </listOfReactants>\n <listOfProducts>\n <speciesReference species=\"species_3\"/>\n </listOfProducts>\n <kineticLaw>\n <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n <apply>\n <times/>\n <ci> compartment_1 </ci>\n <ci> k1 </ci>\n <ci> species_2 </ci>\n </apply>\n </math>\n <listOfParameters>\n <parameter id=\"k1\" name=\"k1\" value=\"0.1\" units=\"unit_0\"/>\n </listOfParameters>\n </kineticLaw>\n </reaction>\n </listOfReactions>\n </model>\n </sbml>\n"
```
becomes
![image](https://user-images.githubusercontent.com/12994749/105231853-5ba9d200-5b1c-11eb-83af-6cf1dc97a6c4.png)

CDATA is the correct way to handle a string in XHTML, though of course I need to confirm that this change works as intended on staging. Manual editing of the HTML in Mindtouch with adding CDATA did return the desired result, so it is likely to work:
![image](https://user-images.githubusercontent.com/12994749/105232064-b5aa9780-5b1c-11eb-9dfe-969863739d76.png)
