### PR TITLE
Fix for ipyleaflet

### DIFF
--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -43,7 +43,8 @@
   }
 }
 
-.thebelab-cell canvas {
+// allows ipyleaflet's overlay to work
+.leaflet-pane canvas {
   max-width: unset;
 }
 

--- a/src/styles/plugin.scss
+++ b/src/styles/plugin.scss
@@ -43,6 +43,10 @@
   }
 }
 
+.thebelab-cell canvas {
+  max-width: unset;
+}
+
 .fa {
   font-family: FontAwesome !important;
 }


### PR DESCRIPTION
Changes css rule for max-width for canvas objects to `unset`, fixes issue where ipyleaflet overlays wouldn't show.

Testing and comparison between the sandboxes on [query](https://query.libretexts.org/?title=Sandboxes%2Fjupyterteam%2540ucdavis.edu) (where ckeditor-binder-plugin uses ipyleaflet-fix branch) and [chem](https://chem.libretexts.org/Sandboxes/jupyterteamucdavisedu) shows no difference between the function of various plugins (with the exception of ipyleaflet of course).

Relevant to issue #107 