### PR TITLE
Upgrade to FontAwesome v5

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/regular.min.css" integrity="sha512-Nqct4Jg8iYwFRs/C34hjAF5og5HONE2mrrUV1JZUswB+YU7vYSPyIjGMq+EAQYDmOsMuO9VIhKpRUa7GjRKVlg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/regular.min.js" integrity="sha512-jR9mIF29jOBsgismrZaiPV9H/VNWOpnILyA4MPEPgJFadfbWT0mQ5MnxCMd+JCYdoTuB2n1SkI00XkELU4ETmg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/v4-shims.min.css" integrity="sha512-iaLhEHW3p+ZNgkDKBi4zEfH+aWAMGJ7I7njqD3jKnbN0ux4Gkumu2vjuI71YUov20OIPl3R32v8HO+V+6OgbvQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/v4-shims.min.js" integrity="sha512-1ND726aZWs77iIUxmOoCUGluOmCT9apImcOVOcDCOSVAUxk3ZSJcuGsHoJ+i4wIOhXieZZx6rY9s6i5xEy1RPg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
     <title>CKeditor Binder Plugin</title>
   </head>

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -10,6 +10,11 @@ loadScript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.
     if (window.define !== undefined) window.define.amd = null;
   });
 
+if (document.currentScript.dataset.loadfa !== "false") { //loads font-awesome scripts unless otherwise disabled
+  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js')
+  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/v4-shims.min.js')
+}
+
 // Adds this plugin to the LibreEditor for later activation
 LibreEditor.binderPlugin = (config) => {
   loadPlugin();

--- a/src/scripts/registerPlugin.js
+++ b/src/scripts/registerPlugin.js
@@ -10,9 +10,9 @@ loadScript('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.
     if (window.define !== undefined) window.define.amd = null;
   });
 
-if (document.currentScript.dataset.loadfa !== "false") { //loads font-awesome scripts unless otherwise disabled
-  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js')
-  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/v4-shims.min.js')
+if (document.currentScript.dataset.loadfa !== 'false') { // loads font-awesome scripts unless otherwise disabled
+  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js');
+  loadScript('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/v4-shims.min.js');
 }
 
 // Adds this plugin to the LibreEditor for later activation


### PR DESCRIPTION
Plugin automatically loads FontAwesome v5 scripts unless explicitly disabled with the `data-loadFA=false` HTML dataset attribute.

The plugin now loads FontAwesome v5 instead of FontAwesome v4. This is expected to be a backwards-compatible update thanks to the v4 shim.

By default, the plugin will auto-load FontAwesome v5. For LibreText's purposes, I have added a dataset flag in which we can optionally disable the autoloading of FontAwesome to prevent conflict with a globally loaded version.
`<script src="../registerPlugin.min.js" data-loadFA="false"></script>`

Closes #157 