### PR TITLE
Fix version printing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Bump version number
       run: |
-        VERSION=$(ls release/ | sort | tail -n1 | sed 's/\.md$//')
+        VERSION=$(ls release/ | sort -V | tail -n1 | sed 's/\.md$//')
         DATE=$(TZ='America/Los_Angeles' date -I)
         VERSION_STR="Release: $VERSION - Date: $DATE"
         sed -i "s/Development Version/$VERSION_STR/" src/scripts/activateThebelab.js


### PR DESCRIPTION
Adds `-V` to the github action sort. Fixes #168.