### PR TITLE
add fa5 to local html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/v4-shims.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
     <title>CKeditor Binder Plugin</title>
   </head>


### PR DESCRIPTION
Since the new FA5 stuff only applies to registerPlugin.js, which is only used in production builds, this adds FA5 to the local development HTML page.